### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wjglerum/quarkus-reactive-examples/security/code-scanning/1](https://github.com/wjglerum/quarkus-reactive-examples/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to the workflow to ensure that the GITHUB_TOKEN used during the workflow runs with the minimum necessary privileges. If your build process does not require writing to the repository, publishing releases, or modifying pull requests/issues/comments, then the minimal safe setting is `contents: read`. This is best set at the workflow's top level (before `jobs:`) if all jobs share the same requirements, or per-job if jobs vary in their needs. In this workflow, insert a permissions block after the `name` and before `on:`. No additional methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
